### PR TITLE
Auto Generate Release File for Addon

### DIFF
--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -1,0 +1,48 @@
+name: Build WoW Addon
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install shutil zipefile
+
+    - name: Build addon
+      run: python build.py
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: <path-to-addon-archive>
+        asset_name: <addon-archive-name>
+        asset_content_type: application/zip

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -27,7 +27,7 @@ jobs:
       id: create_release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       with:
         tag_name: v${{ env.version_num }}
         release_name: Release v${{ env.version_num }}
@@ -37,7 +37,7 @@ jobs:
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install s zipfile
+        pip install zipfile
 
     - name: Build addon
       run: python build.py

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -43,7 +43,3 @@ jobs:
         asset_path: Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip
         asset_name: WCCCAddOn_${{ env.version_num }}.zip
         asset_content_type: application/zip
-    - name: Create and push tag
-      run: |
-        git tag v${{ env.version_num }}
-        git push origin v${{ env.version_num }}

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install shutil zipefile
+        pip install s zipfile
 
     - name: Build addon
       run: python build.py

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -18,10 +18,5 @@ jobs:
       with:
         python-version: 3.x
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install zipfile
-
     - name: Build addon
       run: python build.py

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -13,10 +13,39 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.x
+    - name: Extract version number
+      run: |
+        version_num=$(grep "## Version:" WCCCAddOn/WCCCAddOn.toc | awk '{print $3}')
+        echo "version_num=$version_num" >> $GITHUB_ENV
 
-    - name: Build addon
-      run: python build.py
+    - name: Create release folder and zip archive
+      run: |
+        mkdir -p Builds/${{ env.version_num }}
+        zip -r Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip WCCCAddOn -x "*.git*"
+
+    - name: Add extra files to the archive
+      run: |
+        for extra_file in CHANGELOG.md LICENSE.txt; do
+          zip -u Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip $extra_file -j
+        done
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ env.version_num }}
+        release_name: Release v${{ env.version_num }}
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip
+        asset_name: WCCCAddOn_${{ env.version_num }}.zip
+        asset_content_type: application/zip

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -3,7 +3,7 @@ name: Build WoW Addon
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build:

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -3,7 +3,7 @@ name: Build WoW Addon
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
@@ -23,17 +23,11 @@ jobs:
         mkdir -p Builds/${{ env.version_num }}
         zip -r Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip WCCCAddOn -x "*.git*"
 
-    - name: Add extra files to the archive
-      run: |
-        for extra_file in CHANGELOG.md LICENSE.txt; do
-          zip -u Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip $extra_file -j
-        done
-
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: v${{ env.version_num }}
         release_name: Release v${{ env.version_num }}
@@ -43,7 +37,7 @@ jobs:
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -33,7 +33,7 @@ jobs:
       id: create_release
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       with:
         tag_name: v${{ env.version_num }}
         release_name: Release v${{ env.version_num }}
@@ -43,7 +43,7 @@ jobs:
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -3,7 +3,7 @@ name: Build WoW Addon
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
@@ -43,3 +43,7 @@ jobs:
         asset_path: Builds/${{ env.version_num }}/WCCCAddOn_${{ env.version_num }}.zip
         asset_name: WCCCAddOn_${{ env.version_num }}.zip
         asset_content_type: application/zip
+    - name: Create and push tag
+      run: |
+        git tag v${{ env.version_num }}
+        git push origin v${{ env.version_num }}

--- a/.github/workflows/buildaddon.yml
+++ b/.github/workflows/buildaddon.yml
@@ -25,24 +25,3 @@ jobs:
 
     - name: Build addon
       run: python build.py
-
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: <path-to-addon-archive>
-        asset_name: <addon-archive-name>
-        asset_content_type: application/zip

--- a/WCCCAddOn/WCCCAddOn.toc
+++ b/WCCCAddOn/WCCCAddOn.toc
@@ -2,7 +2,7 @@
 ## Title: WCCC Clubbing Companion
 ## Author: Andy Palmer (Aerthok - Defias Brotherhood EU)
 ## Notes: AddOn of the WCCC. Participate in Clubbing Competitions, view event/broadcast windows and more!
-## Version: 1.5.10
+## Version: 1.5.11
 ## SavedVariables: WCCCDB
 ## Dependencies: Blizzard_Communities
 

--- a/WCCCAddOn/WCCCAddOn.toc
+++ b/WCCCAddOn/WCCCAddOn.toc
@@ -2,7 +2,7 @@
 ## Title: WCCC Clubbing Companion
 ## Author: Andy Palmer (Aerthok - Defias Brotherhood EU)
 ## Notes: AddOn of the WCCC. Participate in Clubbing Competitions, view event/broadcast windows and more!
-## Version: 1.5.11
+## Version: 1.5.10
 ## SavedVariables: WCCCDB
 ## Dependencies: Blizzard_Communities
 


### PR DESCRIPTION
This PR action depreciates the build.py and build.bat scripts (although does remove thm from the repo). Intiially I made it so that it ran build.py but turns out it was just easier to do it natively in actions. The GitHub action will build the AddOn and add it as a release based on the Version variable in WCCCAddOn.toc when a commit is made to the master branch. 

You'll need to add a Personal Access Token to the repo (with permisions on the repo itself) named 'GH_PAT' so that it can create the release. 

Can be extended to autodeploy to CurseForge as well (I just need to bother to go get a API key and stuff so I can test). 